### PR TITLE
Documentation and packaging updates used for Fanime 2023

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ A small inventory ledger, based on Flask.
 [Import Assets](#import-assets)
 []
 
-
 ## Setup
 
 Proper Python distributions are currently a work in progress. Until then, install from a git clone or a source code snapshot from [releases](https://github.com/drahamim/invenflask/releases).
 
 Within the unpacked directory:
 1. Set up virtual environment:
+   If /usr/bin/python is an old version, replace the below "python" with "python3.9"
    ```
    python3 -m venv venv
    ```
@@ -29,39 +29,72 @@ Within the unpacked directory:
    ```
    This will create or overwrite a sqlite3 database named `database.db` in the current directory, which is the only setup the application currently understands.
 
-   Note that this is a destructive operation. If `database.db` already exists, all tables that  
+   Note that this is a destructive operation. If `database.db` already exists, it will be erased.
 
 4. Configuration:
-   1. Generate a secret key:
-      ```
-      $ python
-      >>> import uuid
-      uuid.uuid4().hex
-      ```
-   2. Copy example to config file:
+   1. Copy example to config file:
       ``` 
-      cp example.config.py config.py
+      cp -i example.config.py config.py
       ```
-   3. Copy the output from step 1 into config.py as the value for `SECRET_KEY`
- ## Development Instructions
- Start a development server:
-   ```
-   venv/bin/flask --app invenflask.app run
-   ```
+   2. Set a secret key:
+      ```
+      sed --in-place -e 's/^SECRET_KEY *=.*/SECRET_KEY = "'"$(python3 -c 'import uuid; print(uuid.uuid4().hex);')"'"/' config.py
+      ```
+
+## Development Instructions
+
+Start a development server:
+  ```
+  venv/bin/flask --app invenflask.app run
+  ```
 
 For development, perform an _editable install_ instead at step 2 above, with `pip install -e .`
 
-## Gunicorn (Production)
-Follow Steps 1-4 of the Setup guide then continue with the following:
-1. Install Gunicorn
-   ```
-   venv/bin/pip install gunicorn
-   ```
-2. Run gunicorn
-   ```
-   venv/bin/gunicorn -w 1 --bind 0.0.0.0:8000 wsgi:app
-   ```
+## Production onetime setup
 
+```
+ssh 172.18.1.32
+sudo useradd --create-home invenflask
+sudo chown -R kjw /home/invenflask
+
+# from laptop/dev environment:
+# Note this may need redoing i.e. config.py is edited or the db needs wiping
+scp database.db config.py 172.18.1.32:/home/invenflask/
+
+# back on server, change ownership to invenflask so it can write.
+# TODO: instead make it writable by group invenflask
+ssh 172.18.1.32
+sudo chown invenflask /home/invenflask/database.db
+
+# AS KJW, because I'm lazy and it's easier if I own the files
+ssh kjw@172.18.1.32
+cd /home/invenflask
+python3 -m venv venv
+. venv/bin/activate
+pip install gunicorn
+
+# verify all the pieces are there:
+venv/bin/gunicorn -w 1 --bind 0.0.0.0:8000 wsgi:app
+```
+
+## Deployment via wheel
+
+Build `.whl`
+```
+pip wheel .
+scp init.d_invenflask init.sh wsgi.py invenflask-*.whl 172.18.1.32:/home/invenflask/
+```
+
+Upgrade and restart server
+```
+ssh kjw@172.18.1.32
+cd /home/invenflask
+. venv/bin/activate
+pip3 install invenflask-2.6.1.dev0+gb4afd65.d20230524-py2.py3-none-any.whl
+sudo ./init.d_invenflask install
+sudo /etc/init.d/invenflask restart
+# TODO: turn this into a service so it auto restarts after a crash. should also fix the "stop" bug in initd_invenflask
+```
 
 ## Import Staff
 This can be done on the **Bulk Import** page.
@@ -82,4 +115,4 @@ Assets currently support the following columns:
 ```ID, Model, Status```
 *ID must be unique*
 
-Status is special because by default it will import as **Available** unless a column is specified for unique status tracking
+Status is special because by default it will import as **Available** unless a column is specified for unique status tracking.

--- a/init.d_invenflask
+++ b/init.d_invenflask
@@ -1,0 +1,67 @@
+#!/bin/sh
+
+### BEGIN INIT INFO
+# Provides: invenflask
+# Required-Start: $network $syslog
+# Required-Stop: $network $syslog
+# X-Start-Before:
+# X-Stop-After:
+# Default-Start: 2 3 4
+# Default-Stop: 0 6
+# Short-Description: runs invenflask dev mode
+### END INIT INFO
+
+_stop ()
+{
+  echo killall gunicorn
+  killall gunicorn
+  echo 'STOPPED (I hope)'
+# bug: pid is of the su process. killing it doesn't stop forked off gunicorn processes
+#  if [ -f /var/run/invenflask.pid ] ; then
+#      echo kill $(cat /var/run/invenflask.pid)
+#      kill $(cat /var/run/invenflask.pid)
+#      rm -f /var/run/invenflask.pid
+#      echo 'STOPPED (I hope)'
+#      fi
+}
+
+_start ()
+{
+  _stop # always stop because of above bug
+  for F in /home/invenflask/init.sh /home/kjw/github/invenflask/init.sh ; do
+    if [ -f "${F}" ] ; then
+      echo "${F}"
+      su -c "${F}" invenflask &
+      #echo $! >/var/run/invenflask.pid
+      echo 'STARTED'
+      break
+      fi
+    done
+}
+
+case "$1" in
+  start)
+    _start
+    ;;
+  stop)
+    _stop
+    ;;
+  restart)
+    _stop
+    _start
+    ;;
+  install)
+    cat "$0" >/etc/init.d/invenflask
+    chmod +x /etc/init.d/invenflask
+    ln -sf ../init.d/invenflask /etc/rc2.d/S99invenflask
+    ln -sf ../init.d/invenflask /etc/rc3.d/S99invenflask
+    ln -sf ../init.d/invenflask /etc/rc4.d/S99invenflask
+    ln -sf ../init.d/invenflask /etc/rc6.d/K01invenflask
+    ln -sf ../init.d/invenflask /etc/rc0.d/K01invenflask
+    ;;
+  *)
+    echo 'Usage: $0 [start|stop|restart|install]' >&2
+    exit 1
+    ;;
+esac
+

--- a/init.sh
+++ b/init.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+cd $(dirname $0)
+export VIRTUAL_ENV="/home/invenflask/venv"
+export PATH="$VIRTUAL_ENV/bin:$PATH"
+unset PYTHON_HOME
+exec venv/bin/gunicorn -w 1 --bind 0.0.0.0:8000 wsgi:app 2>&1 | /usr/bin/logger -t invenflask

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,16 +6,17 @@ authors = [
 ]
 description = "A Flask-based asset checkin/checkout system"
 readme = "README.md"
-requires-python = ">=3.10"
+# python 3.9 introduces importlib.resources.files
+requires-python = ">=3.9"
 
 dependencies = [
     "flask >=2.2.2, <3",
     "toml >=0.10.2, <1",
     "pandas ==1.5.3",
     "flask-assets >=2.0",
-    "Flask-Bootstrap >=3.3.5",
-    "Bootstrap-flask >=2.2.0"
-
+    "Bootstrap-flask >=2.2.0",
+    "Flask-Modals >=0.5.1",
+    "wheel >=0"
 ]
 
 [project.scripts]
@@ -30,3 +31,6 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
 write_to = "src/invenflask/_version.py"
+
+[tool.distutils.bdist_wheel]
+universal = true


### PR DESCRIPTION
commit instructions used to install invenflask on production (bebop2) for Fanime 2023. The instructions: init scripts, whl instructions, restarting the service.

Note that these instructions are already out-of-date.